### PR TITLE
Fix contextmenu element property

### DIFF
--- a/assets/js/contextmenu.js
+++ b/assets/js/contextmenu.js
@@ -6,7 +6,7 @@
   /* Helper function to check if the click event happened 
      inside the specfied css element or outside */
   function clickInsideElement(e, className) {
-    var el = e.srsElement || e.target;
+    var el = e.srcElement || e.target;
     if (el.classList.contains(className)) {
       return el;
     } else {
@@ -36,7 +36,7 @@
         document.body.scrollLeft +
         document.documentElement.scrollLeft;
       posY =
-        e.clientY + document.body.srollTop + document.documentElement.scrollTop;
+        e.clientY + document.body.scrollTop + document.documentElement.scrollTop;
     }
 
     return {


### PR DESCRIPTION
## Summary
- fix `srcElement` typo in contextmenu helper
- correct scrollTop calculation

## Testing
- `bundle install` *(fails: Bundler cannot complete)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_684a83ecc8788321ac9b7223ccc050b9